### PR TITLE
feat: add C# syntax highlighting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ difit supports syntax highlighting for multiple programming languages with dynam
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
 - **Web Technologies**: HTML, CSS, JSON, XML, Markdown
 - **Shell Scripts**: `.sh`, `.bash`, `.zsh`, `.fish` files
-- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, C#
-- **Systems Languages**: C, C++, Rust, Go
+- **Backend Languages**: PHP, SQL, Ruby, Java, Scala
+- **Systems Languages**: C, C++, C#, Rust, Go
 - **Mobile Languages**: Swift, Kotlin, Dart
 - **Others**: Python, YAML, Solidity, Vim script
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ difit supports syntax highlighting for multiple programming languages with dynam
 - **JavaScript/TypeScript**: `.js`, `.jsx`, `.ts`, `.tsx`
 - **Web Technologies**: HTML, CSS, JSON, XML, Markdown
 - **Shell Scripts**: `.sh`, `.bash`, `.zsh`, `.fish` files
-- **Backend Languages**: PHP, SQL, Ruby, Java, Scala
+- **Backend Languages**: PHP, SQL, Ruby, Java, Scala, C#
 - **Systems Languages**: C, C++, Rust, Go
 - **Mobile Languages**: Swift, Kotlin, Dart
 - **Others**: Python, YAML, Solidity, Vim script

--- a/src/client/components/PrismSyntaxHighlighter.tsx
+++ b/src/client/components/PrismSyntaxHighlighter.tsx
@@ -77,6 +77,7 @@ function detectLanguage(filename: string): string {
     sol: 'solidity',
     vim: 'vim',
     dart: 'dart',
+    cs: 'csharp',
   };
 
   return extensionMap[ext || ''] || 'text';

--- a/src/client/utils/languageLoader.ts
+++ b/src/client/utils/languageLoader.ts
@@ -27,6 +27,7 @@ export function loadPrismLanguage(lang: string): Promise<void> {
       solidity: () => import('prismjs/components/prism-solidity.js'),
       vim: () => import('prismjs/components/prism-vim.js'),
       dart: () => import('prismjs/components/prism-dart.js'),
+      csharp: () => import('prismjs/components/prism-csharp.js'),
     };
 
     const importFn = languageImports[lang];


### PR DESCRIPTION
- Add C# dynamic language loading in languageLoader.ts
- Add .cs file extension mapping in PrismSyntaxHighlighter.tsx
- Update README.md to include C# in supported languages list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for C# syntax highlighting in the tool.  
* **Documentation**
  * Updated documentation to list C# as a supported backend language.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->